### PR TITLE
Revert "Allow device ID to change"

### DIFF
--- a/components/device/devcore/poll_device.go
+++ b/components/device/devcore/poll_device.go
@@ -143,12 +143,14 @@ func (d *PollDevice) parseDeviceID(js JSON) error {
 			"poll-device: failed to fetch registration: invalid type for device_id")
 	}
 
-	if d.deviceID == "" {
-		syscore.LogInf.Printf("poll-device: device ID received: %s\n", deviceID)
-	} else if d.deviceID != deviceID {
-		syscore.LogInf.Printf("poll-device: device ID changed: cur=%s new=%s\n",
-			d.deviceID, deviceID)
+	if d.deviceID != "" && d.deviceID != deviceID {
+		return fmt.Errorf(
+			"poll-device: failed to fetch registration: device ID mismatch: want=%s got=%s",
+			d.deviceID, deviceID,
+		)
 	}
+
+	syscore.LogInf.Printf("poll-device: device ID received: %s\n", deviceID)
 
 	d.deviceID = deviceID
 

--- a/components/device/devcore/poll_device_test.go
+++ b/components/device/devcore/poll_device_test.go
@@ -454,8 +454,9 @@ func TestPollDeviceRunDeviceIdChanged(t *testing.T) {
 	registrationFetcher.data = registrationData
 
 	err := device.Run()
-	require.Nil(t, err)
-	require.Equal(t, changedDeviceID, dataHandler.registration.DeviceID)
+	require.NotNil(t, err)
+	require.True(t, errors.Is(err, status.StatusError))
+	require.Equal(t, deviceID, dataHandler.registration.DeviceID)
 }
 
 func TestPollDeviceSynchronizeTimeTelemetryAndRegistration(t *testing.T) {


### PR DESCRIPTION
This reverts commit c9bb5985323477981d5338f09f5ea3d53464a25d.

If the device ID changes, the device should be removed from the device-hub and added again, otherwise the persistent storage will contain old device information.