### PR TITLE
Use device URI as a storage key

### DIFF
--- a/components/device/devstore/cache_store_test.go
+++ b/components/device/devstore/cache_store_test.go
@@ -547,7 +547,6 @@ func TestCacheStoreRestoreUnsupportedScheme(t *testing.T) {
 	deviceDesc := "foo-bar-com"
 
 	storageItem := StorageItem{
-		URI:       deviceURI,
 		Desc:      deviceDesc,
 		Timestamp: time.Now().Unix(),
 	}

--- a/components/device/devstore/storage_item.colf
+++ b/components/device/devstore/storage_item.colf
@@ -1,7 +1,6 @@
 package devstore
 
 type StorageItem struct {
-	URI       text
 	Desc      text
 	Timestamp int64
 }


### PR DESCRIPTION
Initially I used hash(URI) to normalize and reduce the original URI. I think it is overkill, since most of the URIs are shot and consume less storage space than the hash(URI).